### PR TITLE
Fix circuit breaker javadoc links

### DIFF
--- a/circuit-breaker.md
+++ b/circuit-breaker.md
@@ -145,11 +145,11 @@ if (breaker.tryAcquirePermit()) {
 
 Failsafe's internal [CircuitBreaker] implementation is space and time efficient, utilizing a single circular data structure to record execution results. Recording an execution and evaluating a threshold has an _O(1)_ time complexity, regardless of the thresholding capacity.
 
-[remaining-delay]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getRemainingDelay--
-[breaker-execution-count]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getExecutionCount--
-[breaker-success-count]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getSuccessCount--
-[breaker-failure-count]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getFailureCount--
-[breaker-success-rate]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getSuccessRate--
-[breaker-failure-rate]: {{ site.url }}/javadoc/dev/failsafe/CircuitBreaker.html#getFailureRate--
+[remaining-delay]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getRemainingDelay--
+[breaker-execution-count]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getExecutionCount--
+[breaker-success-count]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getSuccessCount--
+[breaker-failure-count]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getFailureCount--
+[breaker-success-rate]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getSuccessRate--
+[breaker-failure-rate]: {{ site.url }}/javadoc/core/dev/failsafe/CircuitBreaker.html#getFailureRate--
 
 {% include common-links.html %}


### PR DESCRIPTION
Looks like these links were missing the `core` part of the URI. 